### PR TITLE
Deploy without static HTML export

### DIFF
--- a/src/pages/kohoan.js
+++ b/src/pages/kohoan.js
@@ -20,7 +20,7 @@ import Hr from '../elements/Hr';
 import Spacer from '../elements/Spacer';
 import Span from '../elements/Span';
 import SubSection from '../elements/SubSection';
-import Youtube from '../components/YouTube';
+import Youtube from '../components/Youtube';
 
 import {index, kohoan} from 'src/utils/metadata';
 


### PR DESCRIPTION
- Image components fail with static HTML export.
- Using Cloudinary is cumbersome because the image file names are very hard to control.
