### PR TITLE
Make Percy tests run on CI

### DIFF
--- a/.github/workflows/onPush.yml
+++ b/.github/workflows/onPush.yml
@@ -17,3 +17,5 @@ jobs:
         run: npm run build
       - name: 'Start the server and run tests'
         run: npm run ci
+        env:
+          PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}


### PR DESCRIPTION
fix the failure of Percy snapshot tests on CI