### PR TITLE
Fix Cypress Code Coverage error

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "postci:tests": "npm run report:combined",
     "commit": "git-cz",
     "cy:open": "cypress open --env coverage=false",
+    "precy:run": "rm -r .nyc_output || true",
     "cy:run": "cypress run",
     "dev": "next dev",
     "format": "prettier --ignore-path .gitignore --write \"**/*.+(js|json)\"",


### PR DESCRIPTION
When running `cy:run` locally to generate code coverage report, it returns an error, saying 
```
"after all" hook fails due cy.task('coverageReport').
```
To prevent this from happening, we need to remove the `.nyc_output` directory before each run of `cypress run`.