### PR TITLE
remove Percy visual testing from CI

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,11 +1,6 @@
 name: 'Testing the entire website'
 on: pull_request
 jobs:
-  visual-regression-test:
-    runs-on: ubuntu-latest
-    steps:
-      - name: 'Checkout the repo'
-        uses: actions/checkout@v2
   eslint-jest-cypress:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -6,15 +6,6 @@ jobs:
     steps:
       - name: 'Checkout the repo'
         uses: actions/checkout@v2
-      - name: 'Run Percy with Cypress'
-        uses: cypress-io/github-action@v2
-        with:
-          build: npm run build
-          start: npm start
-          wait-on: 'http://localhost:3000'
-          command: npm run snapshot
-        env:
-          PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}
   eslint-jest-cypress:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Percy visual testing doesn't work properly (images won't be loaded; the space of images won't be reserved). We will instead run Percy locally, to check any visual regresssion.