### PR TITLE
Fix semantic-release configuration (part 2)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,4 +21,5 @@ jobs:
       - name: "Release"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npm run semantic-release


### PR DESCRIPTION
Set NPM_TOKEN, which is required to run semantic-release. This will really close #16