### PR TITLE
remove NPM_TOKEN

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,5 +21,4 @@ jobs:
       - name: "Release"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npm run semantic-release


### PR DESCRIPTION
As we remove the NPM release by configuring semantic-release with #29 , we no longer need NPM_TOKEN.

This should be the last pull request for closing #16