### PR TITLE
Serve Shippori Mincho B1 locally with a subsetted glyph set

### DIFF
--- a/public/fonts/ShipporiMinchoB1-Medium-subset.ttf
+++ b/public/fonts/ShipporiMinchoB1-Medium-subset.ttf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5bff69ce47221829f24ceee7df7fac1f52ff2100591ce30e5eb4c1436edd3bd6
+size 16672

--- a/public/fonts/ShipporiMinchoB1-Medium-subset.woff2
+++ b/public/fonts/ShipporiMinchoB1-Medium-subset.woff2
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fc3406f24be4065043befa55873720b377800b03a77ad2f4d4ab666f5cd959a2
+size 7020

--- a/public/fonts/ShipporiMinchoB1-Medium-subset.zopfli.woff
+++ b/public/fonts/ShipporiMinchoB1-Medium-subset.zopfli.woff
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b0d1b539c0fb23174f852b5a5cab05da8f0da546fdcf3982082c2695b1deb096
+size 8040

--- a/src/utils/GlobalStyle.js
+++ b/src/utils/GlobalStyle.js
@@ -1,8 +1,18 @@
 import {createGlobalStyle} from 'styled-components';
 import {colour} from 'src/utils/colorScheme';
 
+// glyphhanger --whitelist=龍安寺孤篷庵 --subset=ShipporiMinchoB1-Medium.ttf
 const GlobalStyle = createGlobalStyle`
 /* Self-hosted fonts */
+@font-face {
+  font-family: 'Shippori Mincho B1';
+  src: url('fonts/ShipporiMinchoB1-Medium-subset.woff2') format('woff2'),
+       url('fonts/ShipporiMinchoB1-Medium-subset.zopfli.woff') format('woff'),
+       url('fonts/ShipporiMinchoB1-Medium-subset.ttf') format('truetype');
+  font-style: normal;
+  font-weight: 500;
+  font-display: swap;
+}
 @font-face {
   font-family: 'Reforma 1918';
   src: url('fonts/Reforma1918-Blanca.eot?#iefix') format('embedded-opentype'), /* IE8 or earlier */

--- a/src/utils/metadata.js
+++ b/src/utils/metadata.js
@@ -15,7 +15,6 @@ export const index = {
   googleFonts: [
     'family=Cormorant+SC:wght@700',
     'family=Playfair+Display:wght@600',
-    'family=Shippori+Mincho+B1:wght@500',
   ],
 };
 export const kohoan = {


### PR DESCRIPTION
reduce the font file size from 33200KB to 17KB (for TTF format) so it will be downloaded faster, speeding up the loading of the Index page

close #33