### PR TITLE
Serve Shippori Mincho with self-hosted subset font files, instead of using the Google Fonts server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,5 @@ assets-master/
 sketch/
 
 out/
+
+public/fonts/ShipporiMincho-Medium.ttf

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "subset:reforma1918:blanca": "npx glyphhanger http://localhost:3000 --spider --subset=public/fonts/Reforma1918-Blanca.ttf --family='Reforma 1918 Blanca'",
     "subset:reforma1918:gris": "npx glyphhanger http://localhost:3000 --spider --subset=public/fonts/Reforma1918-Gris.ttf --family='Reforma 1918 Gris'",
     "subset:reforma1918:grisItalica": "npx glyphhanger http://localhost:3000 --spider --subset=public/fonts/Reforma1918-GrisItalica.ttf --family='Reforma 1918 Gris Italica'",
+    "subset:shippori:mincho": "npx glyphhanger http://localhost:3000 --spider --subset=public/fonts/ShipporiMincho-Medium.ttf --family='Shippori Mincho'",
     "test": "jest --watch",
     "test:coverage": "npm-run-all --parallel test:coverage:unit test:coverage:e2e",
     "posttest:coverage": "npm run report:combined",

--- a/public/fonts/ShipporiMincho-Medium-subset.ttf
+++ b/public/fonts/ShipporiMincho-Medium-subset.ttf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:253f2b15f42f414e8c6cedf1858b705b116618f13a1e06424a5336838c386805
+size 28500

--- a/public/fonts/ShipporiMincho-Medium-subset.woff2
+++ b/public/fonts/ShipporiMincho-Medium-subset.woff2
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:be7652d153769ba3c0ba310d40ada100f47a668649217aab7abf103fac77bbe4
+size 13340

--- a/public/fonts/ShipporiMincho-Medium-subset.zopfli.woff
+++ b/public/fonts/ShipporiMincho-Medium-subset.zopfli.woff
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:aab0df68cd406897e81c55ee902df01cbaa62d1b08415b86a8091eb1c06adcd6
+size 15436

--- a/src/utils/GlobalStyle.js
+++ b/src/utils/GlobalStyle.js
@@ -5,6 +5,15 @@ import {colour} from 'src/utils/colorScheme';
 const GlobalStyle = createGlobalStyle`
 /* Self-hosted fonts */
 @font-face {
+  font-family: 'Shippori Mincho';
+  src: url('fonts/ShipporiMincho-Medium-subset.woff2') format('woff2'),
+       url('fonts/ShipporiMincho-Medium-subset.zopfli.woff') format('woff'),
+       url('fonts/ShipporiMincho-Medium-subset.ttf') format('truetype');
+  font-style: normal;
+  font-weight: 500;
+  font-display: swap;
+}
+@font-face {
   font-family: 'Shippori Mincho B1';
   src: url('fonts/ShipporiMinchoB1-Medium-subset.woff2') format('woff2'),
        url('fonts/ShipporiMinchoB1-Medium-subset.zopfli.woff') format('woff'),

--- a/src/utils/fontMetrics.js
+++ b/src/utils/fontMetrics.js
@@ -86,6 +86,7 @@ export const reforma1918grisItalica = {
 
 export const shipporiMincho = {
   fontFamily: "'Shippori Mincho', serif",
+  fontWeight: 500, // to match with stroke width of Cormorant Garamond SemiBold (600) and Libre Baskerville 400
 };
 
 export const shipporiMinchoB1 = {

--- a/src/utils/fontScheme.js
+++ b/src/utils/fontScheme.js
@@ -187,7 +187,7 @@ export const font = {
     kanji: {
       family: shipporiMincho.fontFamily,
       size: '1em', // Baseline 1px below LibreBaskerville's, Height 2px above Libre Baskerville's cap height
-      weight: 500, // Match Libre Baskerville 400
+      weight: shipporiMincho.fontWeight,
       lineHeight: 'normal', // line height doesn't change up to around 1.5
     },
     spanLeadIn: {
@@ -311,7 +311,7 @@ export const font = {
     kanji: {
       family: shipporiMincho.fontFamily,
       size: '0.85em' /* to match with Cormorant Garamond body text */,
-      weight: 500 /* to match with stroke width of Cormorant Garamond SemiBold (600) */,
+      weight: shipporiMincho.fontWeight,
     },
     spanLeadIn: {
       family: cormorantSC.fontFamily,

--- a/src/utils/metadata.js
+++ b/src/utils/metadata.js
@@ -25,7 +25,6 @@ export const kohoan = {
     'family=Libre+Baskerville:ital,wght@0,400;0,700;1,400',
     'family=Playfair+Display+SC:wght@400',
     'family=Playfair+Display:wght@600',
-    'family=Shippori+Mincho:wght@500',
   ],
 };
 export const ryoanji = {
@@ -36,6 +35,5 @@ export const ryoanji = {
     'family=Cormorant+Garamond:ital,wght@0,600;1,600',
     'family=Cormorant+SC:wght@600;700',
     'family=Cormorant:wght@700',
-    'family=Shippori+Mincho:wght@500',
   ],
 };


### PR DESCRIPTION
- Remove Shippori Mincho from the query string in the `<link>` tag to use Google Fonts
- Add a npm script to subset Shippori Mincho font file
- Add subset font files of Shippori Mincho
- Define Shippori Mincho with `@font-face`
- Git-ignore the original Shippori Mincho font file