### PR TITLE
Remove visual testing from CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,17 +22,3 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: npm run semantic-release
-  visual-regression-test:
-    runs-on: ubuntu-latest
-    steps:
-      - name: 'Checkout the repo'
-        uses: actions/checkout@v2
-      - name: 'Run Percy with Cypress'
-        uses: cypress-io/github-action@v2
-        with:
-          build: npm run build
-          start: npm start
-          wait-on: 'http://localhost:3000'
-          command: npm run snapshot
-        env:
-          PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,20 +1,6 @@
 name: 'Testing the entire website'
 on: pull_request
 jobs:
-  visual-regression-test:
-    runs-on: ubuntu-latest
-    steps:
-      - name: 'Checkout the repo'
-        uses: actions/checkout@v2
-      - name: 'Run Percy with Cypress'
-        uses: cypress-io/github-action@v2
-        with:
-          build: npm run build
-          start: npm start
-          wait-on: 'http://localhost:3000'
-          command: npm run snapshot
-        env:
-          PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}
   eslint-jest-cypress:
     runs-on: ubuntu-latest
     steps:

--- a/cypress/e2e/snapshot.js
+++ b/cypress/e2e/snapshot.js
@@ -1,6 +1,7 @@
 describe('Integration test with visual testing', () => {
   it('Loads the homepage', () => {
     cy.visit('/');
+    cy.document().its('fonts.status').should('equal', 'loaded');
     cy.scrollTo('bottom', {duration: 2000}); // Scroll to the bottom so all the images will be loaded before taking a snapshot
     // Percy docs recommends scroll-to-bottomjs
     // https://docs.percy.io/docs/capturing-lazy-loading-images#examples
@@ -18,6 +19,7 @@ describe('Integration test with visual testing', () => {
   pages.forEach(page => {
     it(`Loads ${page} page`, () => {
       cy.visit(`/${page}`);
+      cy.document().its('fonts.status').should('equal', 'loaded');
       cy.scrollTo('bottom', {duration: 2000}); // Longer duration won't load more images anyway
       cy.scrollTo('top'); // Scroll up to reveal the top app bar
       cy.findByTestId('top-app-bar').should('be.visible');

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "next build && next export",
     "ci": "start-server-and-test start http://localhost:3000 ci:tests",
-    "ci:tests": "npm-run-all --parallel lint test:coverage:unit test:coverage:e2e snapshot",
+    "ci:tests": "npm-run-all --parallel lint test:coverage:unit test:coverage:e2e",
     "postci:tests": "npm run report:combined",
     "commit": "git-cz",
     "cy:open": "cypress open --env coverage=false",


### PR DESCRIPTION
It never properly works on CI: images and self-hosted fonts won't be rendered.

close #21 